### PR TITLE
Add HTTP file upload support for file outputs

### DIFF
--- a/.github/install_dependencies
+++ b/.github/install_dependencies
@@ -17,7 +17,9 @@ case "${unameOut}" in
             libfftw3-dev \
             librtlsdr-dev \
             libsoapysdr-dev \
-            libpulse-dev
+            libpulse-dev \
+            libcurl4-openssl-dev \
+            pkg-config
 
         (
             git clone https://github.com/f4exb/libmirisdr-4

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && \
       libfftw3-dev \
       libsoapysdr-dev \
       libpulse-dev \
+      libcurl4-openssl-dev \
       \
       git \
       ca-certificates \
@@ -82,6 +83,7 @@ RUN apt-get update && \
     libfftw3-single3 \
     libsoapysdr0.8 \
     libpulse0 \
+    libcurl4 \
     libusb-1.0-0-dev \
     && \
   apt-get clean && \

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ upload_retry_interval = 60;
 upload_pending_on_start = false;
 ```
 
-Failed uploads are retried after `upload_retry_interval` seconds. If `delete_after_upload` is set, successful uploads remove the local copy; otherwise the file is renamed with a `.uploaded` suffix so retries are skipped on subsequent runs. Pending files can be scanned and enqueued on startup when `upload_pending_on_start` is set to `true`.
+Failed uploads are retried after `upload_retry_interval` seconds. If `delete_after_upload` is set, successful uploads remove the local copy; otherwise the file name has `_uploaded` inserted before the extension so retries are skipped on subsequent runs. Pending files can be scanned and enqueued on startup when `upload_pending_on_start` is set to `true`.
 
 ## Credits and thanks
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ When using `file` outputs, recorded files can be uploaded via HTTP POST. Configu
 upload_url = "https://example.com/upload";
 delete_after_upload = true;
 upload_retry_interval = 60;
+upload_pending_on_start = false;
 ```
 
-Failed uploads are retried after `upload_retry_interval` seconds. If `delete_after_upload` is set, successful uploads remove the local copy; otherwise a `.uploaded` marker is written so retries are skipped on subsequent runs. Any pending files found at startup are enqueued automatically.
+Failed uploads are retried after `upload_retry_interval` seconds. If `delete_after_upload` is set, successful uploads remove the local copy; otherwise the file is renamed with a `.uploaded` suffix so retries are skipped on subsequent runs. Pending files can be scanned and enqueued on startup when `upload_pending_on_start` is set to `true`.
 
 ## Credits and thanks
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ upload_retry_interval = 60;
 upload_pending_on_start = false;
 ```
 
-Failed uploads are retried after `upload_retry_interval` seconds. If `delete_after_upload` is set, successful uploads remove the local copy; otherwise the file name has `_uploaded` inserted before the extension so retries are skipped on subsequent runs. Pending files can be scanned and enqueued on startup when `upload_pending_on_start` is set to `true`.
+Failed uploads are retried after a positive `upload_retry_interval` number of seconds. If `delete_after_upload` is set, successful uploads remove the local copy; otherwise the file name has `_uploaded` inserted before the extension so retries are skipped on subsequent runs. Pending files can be scanned and enqueued on startup when `upload_pending_on_start` is set to `true`.
 
 ## Credits and thanks
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ radios are now supported as well.
 
 User's manual is now on the [wiki](https://github.com/rtl-airband/RTLSDR-Airband/wiki).
 
+## File upload configuration
+
+When using `file` outputs, recorded files can be uploaded via HTTP POST. Configure an output with:
+
+```
+upload_url = "https://example.com/upload";
+delete_after_upload = true;
+upload_retry_interval = 60;
+```
+
+Failed uploads are retried after `upload_retry_interval` seconds. If `delete_after_upload` is set, successful uploads remove the local copy; otherwise a `.uploaded` marker is written so retries are skipped on subsequent runs. Any pending files found at startup are enqueued automatically.
+
 ## Credits and thanks
 
 I hereby express my gratitude to everybody who helped with the development and testing

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,6 +66,10 @@ list(APPEND rtl_airband_extra_libs ${SHOUT_LIBRARIES})
 list(APPEND rtl_airband_include_dirs ${SHOUT_INCLUDE_DIRS})
 list(APPEND link_dirs ${SHOUT_LIBRARY_DIRS})
 
+find_package(CURL REQUIRED)
+list(APPEND rtl_airband_extra_libs ${CURL_LIBRARIES})
+list(APPEND rtl_airband_include_dirs ${CURL_INCLUDE_DIRS})
+
 set(CMAKE_REQUIRED_INCLUDES_SAVE ${CMAKE_REQUIRED_INCLUDES})
 set(CMAKE_REQUIRED_LIBRARIES_SAVE ${CMAKE_REQUIRED_LIBRARIES})
 set(CMAKE_REQUIRED_LINK_OPTIONS_SAVE ${CMAKE_REQUIRED_LINK_OPTIONS})
@@ -291,14 +295,15 @@ add_library (rtl_airband_base OBJECT
 	rtl_airband.cpp
 	squelch.cpp
 	ctcss.cpp
-	util.cpp
-	udp_stream.cpp
-	logging.cpp
-	filters.cpp
-	helper_functions.cpp
-	${CMAKE_CURRENT_BINARY_DIR}/version.cpp
-	${rtl_airband_extra_sources}
-	)
+        util.cpp
+        udp_stream.cpp
+        logging.cpp
+        filters.cpp
+        helper_functions.cpp
+        file_upload.cpp
+        ${CMAKE_CURRENT_BINARY_DIR}/version.cpp
+        ${rtl_airband_extra_sources}
+        )
 
 target_include_directories (rtl_airband_base PUBLIC
 	${CMAKE_CURRENT_BINARY_DIR} # needed for config.h

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -98,7 +98,8 @@ static int parse_outputs(libconfig::Setting& outs, channel_t* channel, int i, in
 
             channel->outputs[oo].has_mp3_output = true;
         } else if (!strncmp(outs[o]["type"], "file", 4)) {
-            channel->outputs[oo].data = XCALLOC(1, sizeof(struct file_data));
+            // Allocate with constructor: file_data contains std::string members
+            channel->outputs[oo].data = new file_data();
             channel->outputs[oo].type = O_FILE;
             file_data* fdata = (file_data*)(channel->outputs[oo].data);
 
@@ -112,8 +113,14 @@ static int parse_outputs(libconfig::Setting& outs, channel_t* channel, int i, in
                 cerr << "both directory and filename_template required for file\n";
                 error();
             }
-            fdata->basedir = outs[o]["directory"].c_str();
-            fdata->basename = outs[o]["filename_template"].c_str();
+            if (outs[o]["directory"].getType() != libconfig::Setting::TypeString ||
+                outs[o]["filename_template"].getType() != libconfig::Setting::TypeString) {
+                cerr << "Configuration error: devices.[" << i << "] channels.[" << j << "] outputs.[" << o
+                     << "]: both directory and filename_template must be strings\n";
+                error();
+            }
+            fdata->basedir = static_cast<const char*>(outs[o]["directory"]);
+            fdata->basename = static_cast<const char*>(outs[o]["filename_template"]);
             fdata->dated_subdirectories = outs[o].exists("dated_subdirectories") ? (bool)(outs[o]["dated_subdirectories"]) : false;
             fdata->suffix = ".mp3";
 
@@ -121,7 +128,16 @@ static int parse_outputs(libconfig::Setting& outs, channel_t* channel, int i, in
             fdata->append = (!outs[o].exists("append")) || (bool)(outs[o]["append"]);
             fdata->split_on_transmission = outs[o].exists("split_on_transmission") ? (bool)(outs[o]["split_on_transmission"]) : false;
             fdata->include_freq = outs[o].exists("include_freq") ? (bool)(outs[o]["include_freq"]) : false;
-            fdata->upload_url = outs[o].exists("upload_url") ? outs[o]["upload_url"].c_str() : "";
+            if (outs[o].exists("upload_url")) {
+                if (outs[o]["upload_url"].getType() != libconfig::Setting::TypeString) {
+                    cerr << "Configuration error: devices[" << i << "] channels[" << j << "] outputs[" << o
+                         << "]: upload_url must be a string\n";
+                    error();
+                }
+                fdata->upload_url = static_cast<const char*>(outs[o]["upload_url"]);
+            } else {
+                fdata->upload_url.clear();
+            }
             fdata->delete_after_upload = outs[o].exists("delete_after_upload") ? (bool)(outs[o]["delete_after_upload"]) : false;
             fdata->upload_retry_interval = outs[o].exists("upload_retry_interval") ? (int)(outs[o]["upload_retry_interval"]) : 60;
             if (fdata->upload_retry_interval <= 0) {
@@ -155,7 +171,8 @@ static int parse_outputs(libconfig::Setting& outs, channel_t* channel, int i, in
                 cerr << "Configuration error: mixers.[" << i << "] outputs[" << o << "]: rawfile output is not allowed for mixers\n";
                 error();
             }
-            channel->outputs[oo].data = XCALLOC(1, sizeof(struct file_data));
+            // Allocate with constructor: file_data contains std::string members
+            channel->outputs[oo].data = new file_data();
             channel->outputs[oo].type = O_RAWFILE;
             file_data* fdata = (file_data*)(channel->outputs[oo].data);
 
@@ -165,8 +182,14 @@ static int parse_outputs(libconfig::Setting& outs, channel_t* channel, int i, in
                 error();
             }
 
-            fdata->basedir = outs[o]["directory"].c_str();
-            fdata->basename = outs[o]["filename_template"].c_str();
+            if (outs[o]["directory"].getType() != libconfig::Setting::TypeString ||
+                outs[o]["filename_template"].getType() != libconfig::Setting::TypeString) {
+                cerr << "Configuration error: devices.[" << i << "] channels.[" << j << "] outputs.[" << o
+                     << "]: both directory and filename_template must be strings\n";
+                error();
+            }
+            fdata->basedir = static_cast<const char*>(outs[o]["directory"]);
+            fdata->basename = static_cast<const char*>(outs[o]["filename_template"]);
             fdata->dated_subdirectories = outs[o].exists("dated_subdirectories") ? (bool)(outs[o]["dated_subdirectories"]) : false;
             fdata->suffix = ".cf32";
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -121,6 +121,16 @@ static int parse_outputs(libconfig::Setting& outs, channel_t* channel, int i, in
             fdata->append = (!outs[o].exists("append")) || (bool)(outs[o]["append"]);
             fdata->split_on_transmission = outs[o].exists("split_on_transmission") ? (bool)(outs[o]["split_on_transmission"]) : false;
             fdata->include_freq = outs[o].exists("include_freq") ? (bool)(outs[o]["include_freq"]) : false;
+            fdata->upload_url = outs[o].exists("upload_url") ? outs[o]["upload_url"].c_str() : "";
+            fdata->delete_after_upload = outs[o].exists("delete_after_upload") ? (bool)(outs[o]["delete_after_upload"]) : false;
+            fdata->upload_retry_interval = outs[o].exists("upload_retry_interval") ? (int)(outs[o]["upload_retry_interval"]) : 60;
+            if (outs[o].exists("upload_url") && fdata->upload_url.empty()) {
+                cerr << "Configuration error: devices[" << i << "] channels[" << j << "] outputs[" << o << "]: upload_url may not be empty\n";
+                error();
+            }
+            if (!fdata->upload_url.empty()) {
+                log(LOG_INFO, "File output will upload to %s delete_after_upload=%d retry_interval=%d\n", fdata->upload_url.c_str(), fdata->delete_after_upload, fdata->upload_retry_interval);
+            }
 
             channel->outputs[oo].has_mp3_output = true;
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -124,12 +124,13 @@ static int parse_outputs(libconfig::Setting& outs, channel_t* channel, int i, in
             fdata->upload_url = outs[o].exists("upload_url") ? outs[o]["upload_url"].c_str() : "";
             fdata->delete_after_upload = outs[o].exists("delete_after_upload") ? (bool)(outs[o]["delete_after_upload"]) : false;
             fdata->upload_retry_interval = outs[o].exists("upload_retry_interval") ? (int)(outs[o]["upload_retry_interval"]) : 60;
+            fdata->upload_pending_on_start = outs[o].exists("upload_pending_on_start") ? (bool)(outs[o]["upload_pending_on_start"]) : false;
             if (outs[o].exists("upload_url") && fdata->upload_url.empty()) {
                 cerr << "Configuration error: devices[" << i << "] channels[" << j << "] outputs[" << o << "]: upload_url may not be empty\n";
                 error();
             }
             if (!fdata->upload_url.empty()) {
-                log(LOG_INFO, "File output will upload to %s delete_after_upload=%d retry_interval=%d\n", fdata->upload_url.c_str(), fdata->delete_after_upload, fdata->upload_retry_interval);
+                log(LOG_INFO, "File output will upload to %s delete_after_upload=%d retry_interval=%d scan_on_start=%d\n", fdata->upload_url.c_str(), fdata->delete_after_upload, fdata->upload_retry_interval, fdata->upload_pending_on_start);
             }
 
             channel->outputs[oo].has_mp3_output = true;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -113,10 +113,8 @@ static int parse_outputs(libconfig::Setting& outs, channel_t* channel, int i, in
                 cerr << "both directory and filename_template required for file\n";
                 error();
             }
-            if (outs[o]["directory"].getType() != libconfig::Setting::TypeString ||
-                outs[o]["filename_template"].getType() != libconfig::Setting::TypeString) {
-                cerr << "Configuration error: devices.[" << i << "] channels.[" << j << "] outputs.[" << o
-                     << "]: both directory and filename_template must be strings\n";
+            if (outs[o]["directory"].getType() != libconfig::Setting::TypeString || outs[o]["filename_template"].getType() != libconfig::Setting::TypeString) {
+                cerr << "Configuration error: devices.[" << i << "] channels.[" << j << "] outputs.[" << o << "]: both directory and filename_template must be strings\n";
                 error();
             }
             fdata->basedir = static_cast<const char*>(outs[o]["directory"]);
@@ -130,8 +128,7 @@ static int parse_outputs(libconfig::Setting& outs, channel_t* channel, int i, in
             fdata->include_freq = outs[o].exists("include_freq") ? (bool)(outs[o]["include_freq"]) : false;
             if (outs[o].exists("upload_url")) {
                 if (outs[o]["upload_url"].getType() != libconfig::Setting::TypeString) {
-                    cerr << "Configuration error: devices[" << i << "] channels[" << j << "] outputs[" << o
-                         << "]: upload_url must be a string\n";
+                    cerr << "Configuration error: devices[" << i << "] channels[" << j << "] outputs[" << o << "]: upload_url must be a string\n";
                     error();
                 }
                 fdata->upload_url = static_cast<const char*>(outs[o]["upload_url"]);
@@ -150,7 +147,8 @@ static int parse_outputs(libconfig::Setting& outs, channel_t* channel, int i, in
                 error();
             }
             if (!fdata->upload_url.empty()) {
-                log(LOG_INFO, "File output will upload to %s delete_after_upload=%d retry_interval=%d scan_on_start=%d\n", fdata->upload_url.c_str(), fdata->delete_after_upload, fdata->upload_retry_interval, fdata->upload_pending_on_start);
+                log(LOG_INFO, "File output will upload to %s delete_after_upload=%d retry_interval=%d scan_on_start=%d\n", fdata->upload_url.c_str(), fdata->delete_after_upload,
+                    fdata->upload_retry_interval, fdata->upload_pending_on_start);
             }
 
             channel->outputs[oo].has_mp3_output = true;
@@ -182,10 +180,8 @@ static int parse_outputs(libconfig::Setting& outs, channel_t* channel, int i, in
                 error();
             }
 
-            if (outs[o]["directory"].getType() != libconfig::Setting::TypeString ||
-                outs[o]["filename_template"].getType() != libconfig::Setting::TypeString) {
-                cerr << "Configuration error: devices.[" << i << "] channels.[" << j << "] outputs.[" << o
-                     << "]: both directory and filename_template must be strings\n";
+            if (outs[o]["directory"].getType() != libconfig::Setting::TypeString || outs[o]["filename_template"].getType() != libconfig::Setting::TypeString) {
+                cerr << "Configuration error: devices.[" << i << "] channels.[" << j << "] outputs.[" << o << "]: both directory and filename_template must be strings\n";
                 error();
             }
             fdata->basedir = static_cast<const char*>(outs[o]["directory"]);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -124,6 +124,10 @@ static int parse_outputs(libconfig::Setting& outs, channel_t* channel, int i, in
             fdata->upload_url = outs[o].exists("upload_url") ? outs[o]["upload_url"].c_str() : "";
             fdata->delete_after_upload = outs[o].exists("delete_after_upload") ? (bool)(outs[o]["delete_after_upload"]) : false;
             fdata->upload_retry_interval = outs[o].exists("upload_retry_interval") ? (int)(outs[o]["upload_retry_interval"]) : 60;
+            if (fdata->upload_retry_interval <= 0) {
+                cerr << "Configuration error: devices[" << i << "] channels[" << j << "] outputs[" << o << "]: upload_retry_interval must be positive\n";
+                error();
+            }
             fdata->upload_pending_on_start = outs[o].exists("upload_pending_on_start") ? (bool)(outs[o]["upload_pending_on_start"]) : false;
             if (outs[o].exists("upload_url") && fdata->upload_url.empty()) {
                 cerr << "Configuration error: devices[" << i << "] channels[" << j << "] outputs[" << o << "]: upload_url may not be empty\n";

--- a/src/file_upload.cpp
+++ b/src/file_upload.cpp
@@ -71,7 +71,6 @@ void enqueue_upload(const std::string& path, const file_data& data) {
         queue_cv.notify_all();
     }
 }
-
 void init_file_uploader() {
     curl_global_init(CURL_GLOBAL_DEFAULT);
     uploader_running = true;

--- a/src/file_upload.cpp
+++ b/src/file_upload.cpp
@@ -1,0 +1,140 @@
+#include "file_upload.h"
+#include <queue>
+#include <mutex>
+#include <dirent.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <cstdio>
+#include <curl/curl.h>
+
+struct upload_task {
+    std::string path;
+    file_data config;
+    time_t next_try;
+};
+
+static std::queue<upload_task> upload_queue;
+static std::mutex queue_mutex;
+
+void init_file_uploader() {
+    curl_global_init(CURL_GLOBAL_DEFAULT);
+}
+
+static bool upload_file(const upload_task& task) {
+    CURL* curl = curl_easy_init();
+    if (!curl)
+        return false;
+
+    curl_mime* form = curl_mime_init(curl);
+    curl_mimepart* part = curl_mime_addpart(form);
+    curl_mime_name(part, "file");
+    curl_mime_filedata(part, task.path.c_str());
+
+    curl_easy_setopt(curl, CURLOPT_URL, task.config.upload_url.c_str());
+    curl_easy_setopt(curl, CURLOPT_MIMEPOST, form);
+
+    CURLcode res = curl_easy_perform(curl);
+    curl_mime_free(form);
+    curl_easy_cleanup(curl);
+
+    return res == CURLE_OK;
+}
+
+void enqueue_upload(const std::string& path, const file_data& data) {
+    if (path.empty() || data.upload_url.empty())
+        return;
+    std::lock_guard<std::mutex> lock(queue_mutex);
+    upload_queue.push({path, data, 0});
+}
+
+void process_upload_queue() {
+    std::queue<upload_task> work;
+    {
+        std::lock_guard<std::mutex> lock(queue_mutex);
+        std::swap(work, upload_queue);
+    }
+    while (!work.empty()) {
+        upload_task task = work.front();
+        work.pop();
+        time_t now = time(NULL);
+        if (task.next_try > now) {
+            std::lock_guard<std::mutex> lock(queue_mutex);
+            upload_queue.push(task);
+            continue;
+        }
+        if (upload_file(task)) {
+            if (task.config.delete_after_upload) {
+                unlink(task.path.c_str());
+            } else {
+                std::string marker = task.path + ".uploaded";
+                FILE* f = fopen(marker.c_str(), "w");
+                if (f)
+                    fclose(f);
+            }
+        } else {
+            task.next_try = time(NULL) + task.config.upload_retry_interval;
+            std::lock_guard<std::mutex> lock(queue_mutex);
+            upload_queue.push(task);
+        }
+    }
+}
+
+static void scan_directory(const file_data& cfg, const std::string& dir) {
+    DIR* d = opendir(dir.c_str());
+    if (!d)
+        return;
+    struct dirent* ent;
+    while ((ent = readdir(d))) {
+        if (ent->d_name[0] == '.')
+            continue;
+        std::string path = dir + "/" + ent->d_name;
+        if (ent->d_type == DT_DIR && cfg.dated_subdirectories) {
+            scan_directory(cfg, path);
+        } else if (ent->d_type == DT_REG) {
+            if ((path.size() >= sizeof(".uploaded") - 1 &&
+                 path.substr(path.size() - (sizeof(".uploaded") - 1)) == ".uploaded") ||
+                access((path + ".uploaded").c_str(), F_OK) == 0) {
+                continue;
+            }
+            if (cfg.suffix.empty() ||
+                (path.size() >= cfg.suffix.size() &&
+                 path.substr(path.size() - cfg.suffix.size()) == cfg.suffix)) {
+                enqueue_upload(path, cfg);
+            }
+        }
+    }
+    closedir(d);
+}
+
+void scan_pending_uploads() {
+    for (int i = 0; i < device_count; i++) {
+        device_t* dev = devices + i;
+        for (int j = 0; j < dev->channel_count; j++) {
+            channel_t* ch = &dev->channels[j];
+            for (int k = 0; k < ch->output_count; k++) {
+                output_t* out = &ch->outputs[k];
+                if (out->type == O_FILE) {
+                    file_data* fdata = (file_data*)out->data;
+                    if (fdata && !fdata->upload_url.empty()) {
+                        scan_directory(*fdata, fdata->basedir);
+                    }
+                }
+            }
+        }
+    }
+    for (int i = 0; i < mixer_count; i++) {
+        if (!mixers[i].enabled)
+            continue;
+        channel_t* ch = &mixers[i].channel;
+        for (int k = 0; k < ch->output_count; k++) {
+            output_t* out = &ch->outputs[k];
+            if (out->type == O_FILE) {
+                file_data* fdata = (file_data*)out->data;
+                if (fdata && !fdata->upload_url.empty()) {
+                    scan_directory(*fdata, fdata->basedir);
+                }
+            }
+        }
+    }
+}

--- a/src/file_upload.cpp
+++ b/src/file_upload.cpp
@@ -186,4 +186,3 @@ void scan_pending_uploads() {
         }
     }
 }
-

--- a/src/file_upload.h
+++ b/src/file_upload.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <string>
+#include "rtl_airband.h"
+
+void init_file_uploader();
+void enqueue_upload(const std::string& path, const file_data& data);
+void process_upload_queue();
+void scan_pending_uploads();

--- a/src/file_upload.h
+++ b/src/file_upload.h
@@ -5,3 +5,4 @@
 void init_file_uploader();
 void enqueue_upload(const std::string& path, const file_data& data);
 void scan_pending_uploads();
+void shutdown_file_uploader();

--- a/src/file_upload.h
+++ b/src/file_upload.h
@@ -4,5 +4,4 @@
 
 void init_file_uploader();
 void enqueue_upload(const std::string& path, const file_data& data);
-void process_upload_queue();
 void scan_pending_uploads();

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -51,6 +51,7 @@
 #include "helper_functions.h"
 #include "input-common.h"
 #include "rtl_airband.h"
+#include "file_upload.h"
 
 void shout_setup(icecast_data* icecast, mix_modes mixmode) {
     int ret;
@@ -334,10 +335,15 @@ static void close_file(output_t* output) {
         fwrite(output->lamebuf, 1, lametag_size, fdata->f);
     }
 
+    std::string finished_path;
     if (fdata->f) {
         fclose(fdata->f);
         fdata->f = NULL;
         rename_if_exists(fdata->file_path_tmp.c_str(), fdata->file_path.c_str());
+        finished_path = fdata->file_path;
+    }
+    if (!finished_path.empty() && !fdata->upload_url.empty()) {
+        enqueue_upload(finished_path, *fdata);
     }
     fdata->file_path.clear();
     fdata->file_path_tmp.clear();
@@ -1028,6 +1034,7 @@ void* output_check_thread(void*) {
                 }
             }
         }
+        process_upload_queue();
     }
     return 0;
 }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1034,7 +1034,6 @@ void* output_check_thread(void*) {
                 }
             }
         }
-        process_upload_queue();
     }
     return 0;
 }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -48,10 +48,10 @@
 #include <sstream>
 #include <string>
 #include "config.h"
+#include "file_upload.h"
 #include "helper_functions.h"
 #include "input-common.h"
 #include "rtl_airband.h"
-#include "file_upload.h"
 
 void shout_setup(icecast_data* icecast, mix_modes mixmode) {
     int ret;

--- a/src/rtl_airband.cpp
+++ b/src/rtl_airband.cpp
@@ -1154,6 +1154,8 @@ int main(int argc, char* argv[]) {
         }
     }
 
+    shutdown_file_uploader();
+
     close_debug();
 #ifdef WITH_PROFILING
     ProfilerStop();

--- a/src/rtl_airband.cpp
+++ b/src/rtl_airband.cpp
@@ -59,6 +59,7 @@
 #include "input-common.h"
 #include "logging.h"
 #include "rtl_airband.h"
+#include "file_upload.h"
 #include "squelch.h"
 
 #ifdef WITH_PROFILING
@@ -1038,6 +1039,8 @@ int main(int argc, char* argv[]) {
             }
         }
     }
+    init_file_uploader();
+    scan_pending_uploads();
     THREAD output_check;
     pthread_create(&output_check, NULL, &output_check_thread, NULL);
 

--- a/src/rtl_airband.cpp
+++ b/src/rtl_airband.cpp
@@ -56,10 +56,10 @@
 #include <ctime>
 #include <iostream>
 #include <libconfig.h++>
+#include "file_upload.h"
 #include "input-common.h"
 #include "logging.h"
 #include "rtl_airband.h"
-#include "file_upload.h"
 #include "squelch.h"
 
 #ifdef WITH_PROFILING

--- a/src/rtl_airband.h
+++ b/src/rtl_airband.h
@@ -143,6 +143,7 @@ struct file_data {
     std::string upload_url;
     bool delete_after_upload;
     int upload_retry_interval;
+    bool upload_pending_on_start;
     timeval open_time;
     timeval last_write_time;
     FILE* f;

--- a/src/rtl_airband.h
+++ b/src/rtl_airband.h
@@ -140,6 +140,9 @@ struct file_data {
     bool append;
     bool split_on_transmission;
     bool include_freq;
+    std::string upload_url;
+    bool delete_after_upload;
+    int upload_retry_interval;
     timeval open_time;
     timeval last_write_time;
     FILE* f;


### PR DESCRIPTION
## Summary
- allow file outputs to specify `upload_url`, `delete_after_upload`, and `upload_retry_interval` options
- queue closed recordings for POST upload via libcurl with retry, optional deletion, and `.uploaded` marker when keeping files
- scan directories for pending uploads on startup and skip those already marked as uploaded

## Testing
- `pre-commit run --files README.md src/config.cpp src/file_upload.cpp src/rtl_airband.h` *(command not found: pre-commit)*
- `apt-get update` *(fails: repository InRelease 403 Forbidden)*
- `apt-get install -y pre-commit` *(fails: Unable to locate package pre-commit)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit due to proxy 403)*
- `cmake -S . -B build` *(fails: The following required packages were not found: libconfig++)*

------
https://chatgpt.com/codex/tasks/task_e_68956f0ab9e88333ab074995ee8504da