### PR TITLE
Delay upload until recording finalized

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ upload_retry_interval = 60;
 upload_pending_on_start = false;
 ```
 
-Failed uploads are retried after a positive `upload_retry_interval` number of seconds. If `delete_after_upload` is set, successful uploads remove the local copy; otherwise the file name has `_uploaded` inserted before the extension so retries are skipped on subsequent runs. Uploads are initially attempted about one second after a file is closed to ensure the recording is fully written. Pending files can be scanned and enqueued on startup when `upload_pending_on_start` is set to `true`.
+`upload_retry_interval` must be greater than zero and defaults to 60 seconds. Failed uploads are retried after that interval. If `delete_after_upload` is set, successful uploads remove the local copy; otherwise the file name has `_uploaded` inserted before the extension so retries are skipped on subsequent runs. Uploads are initially attempted about one second after a file is closed to ensure the recording is fully written. Pending files can be scanned and enqueued on startup when `upload_pending_on_start` is set to `true`.
 
 ## Credits and thanks
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ radios are now supported as well.
 
 User's manual is now on the [wiki](https://github.com/rtl-airband/RTLSDR-Airband/wiki).
 
+## File upload configuration
+
+When using `file` outputs, recorded files can be uploaded via HTTP POST. Configure an output with:
+
+```
+upload_url = "https://example.com/upload";
+delete_after_upload = true;
+upload_retry_interval = 60;
+upload_pending_on_start = false;
+```
+
+Failed uploads are retried after a positive `upload_retry_interval` number of seconds. If `delete_after_upload` is set, successful uploads remove the local copy; otherwise the file name has `_uploaded` inserted before the extension so retries are skipped on subsequent runs. Uploads are initially attempted about one second after a file is closed to ensure the recording is fully written. Pending files can be scanned and enqueued on startup when `upload_pending_on_start` is set to `true`.
+
 ## Credits and thanks
 
 I hereby express my gratitude to everybody who helped with the development and testing

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,6 +66,10 @@ list(APPEND rtl_airband_extra_libs ${SHOUT_LIBRARIES})
 list(APPEND rtl_airband_include_dirs ${SHOUT_INCLUDE_DIRS})
 list(APPEND link_dirs ${SHOUT_LIBRARY_DIRS})
 
+find_package(CURL REQUIRED)
+list(APPEND rtl_airband_extra_libs ${CURL_LIBRARIES})
+list(APPEND rtl_airband_include_dirs ${CURL_INCLUDE_DIRS})
+
 set(CMAKE_REQUIRED_INCLUDES_SAVE ${CMAKE_REQUIRED_INCLUDES})
 set(CMAKE_REQUIRED_LIBRARIES_SAVE ${CMAKE_REQUIRED_LIBRARIES})
 set(CMAKE_REQUIRED_LINK_OPTIONS_SAVE ${CMAKE_REQUIRED_LINK_OPTIONS})
@@ -291,14 +295,15 @@ add_library (rtl_airband_base OBJECT
 	rtl_airband.cpp
 	squelch.cpp
 	ctcss.cpp
-	util.cpp
-	udp_stream.cpp
-	logging.cpp
-	filters.cpp
-	helper_functions.cpp
-	${CMAKE_CURRENT_BINARY_DIR}/version.cpp
-	${rtl_airband_extra_sources}
-	)
+        util.cpp
+        udp_stream.cpp
+        logging.cpp
+        filters.cpp
+        helper_functions.cpp
+        file_upload.cpp
+        ${CMAKE_CURRENT_BINARY_DIR}/version.cpp
+        ${rtl_airband_extra_sources}
+        )
 
 target_include_directories (rtl_airband_base PUBLIC
 	${CMAKE_CURRENT_BINARY_DIR} # needed for config.h

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -121,6 +121,21 @@ static int parse_outputs(libconfig::Setting& outs, channel_t* channel, int i, in
             fdata->append = (!outs[o].exists("append")) || (bool)(outs[o]["append"]);
             fdata->split_on_transmission = outs[o].exists("split_on_transmission") ? (bool)(outs[o]["split_on_transmission"]) : false;
             fdata->include_freq = outs[o].exists("include_freq") ? (bool)(outs[o]["include_freq"]) : false;
+            fdata->upload_url = outs[o].exists("upload_url") ? outs[o]["upload_url"].c_str() : "";
+            fdata->delete_after_upload = outs[o].exists("delete_after_upload") ? (bool)(outs[o]["delete_after_upload"]) : false;
+            fdata->upload_retry_interval = outs[o].exists("upload_retry_interval") ? (int)(outs[o]["upload_retry_interval"]) : 60;
+            if (fdata->upload_retry_interval <= 0) {
+                cerr << "Configuration error: devices[" << i << "] channels[" << j << "] outputs[" << o << "]: upload_retry_interval must be positive\n";
+                error();
+            }
+            fdata->upload_pending_on_start = outs[o].exists("upload_pending_on_start") ? (bool)(outs[o]["upload_pending_on_start"]) : false;
+            if (outs[o].exists("upload_url") && fdata->upload_url.empty()) {
+                cerr << "Configuration error: devices[" << i << "] channels[" << j << "] outputs[" << o << "]: upload_url may not be empty\n";
+                error();
+            }
+            if (!fdata->upload_url.empty()) {
+                log(LOG_INFO, "File output will upload to %s delete_after_upload=%d retry_interval=%d scan_on_start=%d\n", fdata->upload_url.c_str(), fdata->delete_after_upload, fdata->upload_retry_interval, fdata->upload_pending_on_start);
+            }
 
             channel->outputs[oo].has_mp3_output = true;
 

--- a/src/file_upload.cpp
+++ b/src/file_upload.cpp
@@ -1,0 +1,196 @@
+#include "file_upload.h"
+#include "logging.h"
+#include <queue>
+#include <set>
+#include <mutex>
+#include <thread>
+#include <atomic>
+#include <condition_variable>
+#include <chrono>
+#include <dirent.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <cstdio>
+#include <curl/curl.h>
+
+struct upload_task {
+    std::string path;
+    file_data config;
+    time_t next_try;
+};
+
+struct task_compare {
+    bool operator()(const upload_task& a, const upload_task& b) const {
+        return a.next_try > b.next_try;
+    }
+};
+
+static std::priority_queue<upload_task, std::vector<upload_task>, task_compare> upload_queue;
+static std::set<std::string> queued_files;
+static std::mutex queue_mutex;
+static std::condition_variable queue_cv;
+static std::atomic<bool> uploader_running;
+static std::thread uploader_thread;
+
+static bool upload_file(const upload_task& task) {
+    CURL* curl = curl_easy_init();
+    if (!curl) {
+        log(LOG_ERR, "curl_easy_init() failed\n");
+        return false;
+    }
+
+    curl_mime* form = curl_mime_init(curl);
+    curl_mimepart* part = curl_mime_addpart(form);
+    curl_mime_name(part, "file");
+    curl_mime_filedata(part, task.path.c_str());
+
+    curl_easy_setopt(curl, CURLOPT_URL, task.config.upload_url.c_str());
+    curl_easy_setopt(curl, CURLOPT_MIMEPOST, form);
+
+    CURLcode res = curl_easy_perform(curl);
+    long http_code = 0;
+    if (res == CURLE_OK) {
+        curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    }
+    if (res != CURLE_OK) {
+        log(LOG_ERR, "Upload of %s failed: %s\n", task.path.c_str(), curl_easy_strerror(res));
+    } else if (http_code < 200 || http_code >= 300) {
+        log(LOG_ERR, "Upload of %s returned HTTP %ld\n", task.path.c_str(), http_code);
+    }
+
+    curl_mime_free(form);
+    curl_easy_cleanup(curl);
+
+    return res == CURLE_OK && http_code >= 200 && http_code < 300;
+}
+
+void enqueue_upload(const std::string& path, const file_data& data) {
+    if (path.empty() || data.upload_url.empty())
+        return;
+    std::lock_guard<std::mutex> lock(queue_mutex);
+    if (queued_files.insert(path).second) {
+        upload_queue.push({path, data, time(NULL) + 1});
+        queue_cv.notify_all();
+    }
+}
+
+void init_file_uploader() {
+    curl_global_init(CURL_GLOBAL_DEFAULT);
+    uploader_running = true;
+    uploader_thread = std::thread([]() {
+        std::unique_lock<std::mutex> lock(queue_mutex);
+        while (uploader_running) {
+            if (upload_queue.empty()) {
+                queue_cv.wait(lock, [] { return !uploader_running || !upload_queue.empty(); });
+                if (!uploader_running)
+                    break;
+            } else {
+                time_t now = time(NULL);
+                time_t next = upload_queue.top().next_try;
+                if (next > now) {
+                    queue_cv.wait_until(lock, std::chrono::system_clock::from_time_t(next));
+                    continue;
+                }
+
+                upload_task task = upload_queue.top();
+                upload_queue.pop();
+                queued_files.erase(task.path);
+                lock.unlock();
+
+                bool ok = upload_file(task);
+                if (ok) {
+                    if (task.config.delete_after_upload) {
+                        unlink(task.path.c_str());
+                    } else {
+                        std::string renamed = task.path;
+                        size_t dot = renamed.find_last_of('.');
+                        if (dot != std::string::npos) {
+                            renamed.insert(dot, "_uploaded");
+                        } else {
+                            renamed += "_uploaded";
+                        }
+                        rename(task.path.c_str(), renamed.c_str());
+                    }
+                } else {
+                    task.next_try = time(NULL) + task.config.upload_retry_interval;
+                    std::lock_guard<std::mutex> relock(queue_mutex);
+                    queued_files.insert(task.path);
+                    upload_queue.push(task);
+                    queue_cv.notify_all();
+                }
+                lock.lock();
+            }
+        }
+    });
+}
+
+void shutdown_file_uploader() {
+    uploader_running = false;
+    queue_cv.notify_all();
+    if (uploader_thread.joinable())
+        uploader_thread.join();
+    curl_global_cleanup();
+}
+
+static void scan_directory(const file_data& cfg, const std::string& dir) {
+    DIR* d = opendir(dir.c_str());
+    if (!d)
+        return;
+    struct dirent* ent;
+    while ((ent = readdir(d))) {
+        if (ent->d_name[0] == '.')
+            continue;
+        std::string path = dir + "/" + ent->d_name;
+        if (ent->d_type == DT_DIR && cfg.dated_subdirectories) {
+            scan_directory(cfg, path);
+        } else if (ent->d_type == DT_REG) {
+            std::string filename = ent->d_name;
+            size_t dot = filename.find_last_of('.');
+            std::string stem = dot != std::string::npos ? filename.substr(0, dot) : filename;
+            if (stem.size() >= sizeof("_uploaded") - 1 &&
+                stem.substr(stem.size() - (sizeof("_uploaded") - 1)) == "_uploaded") {
+                continue;
+            }
+            if (cfg.suffix.empty() ||
+                (path.size() >= cfg.suffix.size() &&
+                 path.substr(path.size() - cfg.suffix.size()) == cfg.suffix)) {
+                enqueue_upload(path, cfg);
+            }
+        }
+    }
+    closedir(d);
+}
+
+void scan_pending_uploads() {
+    for (int i = 0; i < device_count; i++) {
+        device_t* dev = devices + i;
+        for (int j = 0; j < dev->channel_count; j++) {
+            channel_t* ch = &dev->channels[j];
+            for (int k = 0; k < ch->output_count; k++) {
+                output_t* out = &ch->outputs[k];
+                if (out->type == O_FILE) {
+                    file_data* fdata = (file_data*)out->data;
+                    if (fdata && !fdata->upload_url.empty() && fdata->upload_pending_on_start) {
+                        scan_directory(*fdata, fdata->basedir);
+                    }
+                }
+            }
+        }
+    }
+    for (int i = 0; i < mixer_count; i++) {
+        if (!mixers[i].enabled)
+            continue;
+        channel_t* ch = &mixers[i].channel;
+        for (int k = 0; k < ch->output_count; k++) {
+            output_t* out = &ch->outputs[k];
+            if (out->type == O_FILE) {
+                file_data* fdata = (file_data*)out->data;
+                if (fdata && !fdata->upload_url.empty() && fdata->upload_pending_on_start) {
+                    scan_directory(*fdata, fdata->basedir);
+                }
+            }
+        }
+    }
+}
+

--- a/src/file_upload.h
+++ b/src/file_upload.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <string>
+#include "rtl_airband.h"
+
+void init_file_uploader();
+void enqueue_upload(const std::string& path, const file_data& data);
+void scan_pending_uploads();
+void shutdown_file_uploader();

--- a/src/rtl_airband.cpp
+++ b/src/rtl_airband.cpp
@@ -59,6 +59,7 @@
 #include "input-common.h"
 #include "logging.h"
 #include "rtl_airband.h"
+#include "file_upload.h"
 #include "squelch.h"
 
 #ifdef WITH_PROFILING
@@ -1038,6 +1039,8 @@ int main(int argc, char* argv[]) {
             }
         }
     }
+    init_file_uploader();
+    scan_pending_uploads();
     THREAD output_check;
     pthread_create(&output_check, NULL, &output_check_thread, NULL);
 
@@ -1150,6 +1153,8 @@ int main(int argc, char* argv[]) {
             }
         }
     }
+
+    shutdown_file_uploader();
 
     close_debug();
 #ifdef WITH_PROFILING

--- a/src/rtl_airband.h
+++ b/src/rtl_airband.h
@@ -140,6 +140,10 @@ struct file_data {
     bool append;
     bool split_on_transmission;
     bool include_freq;
+    std::string upload_url;
+    bool delete_after_upload;
+    int upload_retry_interval;
+    bool upload_pending_on_start;
     timeval open_time;
     timeval last_write_time;
     FILE* f;


### PR DESCRIPTION
## Summary
- fsync and verify renames when closing recordings so files are fully written
- wait briefly before first upload attempt to avoid reading incomplete files
- document the one-second post-close delay for uploads

## Testing
- `pre-commit run --files README.md src/file_upload.cpp src/output.cpp` *(command not found: pre-commit)*
- `apt-get update` *(403 Forbidden repository errors)*
- `cmake -S . -B build` *(fails: libconfig++ not found)*

------
https://chatgpt.com/codex/tasks/task_e_68956f0ab9e88333ab074995ee8504da