### PR TITLE
Add optional AGC mode for RTL-SDR inputs

### DIFF
--- a/src/input-rtlsdr.h
+++ b/src/input-rtlsdr.h
@@ -29,4 +29,5 @@ typedef struct {
     int correction;     // PPM correction
     int gain;           // gain in tenths of dB
     int bufcnt;         // libusb buffer count
+    bool agc;           // enable AGC
 } rtlsdr_dev_data_t;


### PR DESCRIPTION
## Summary
- allow RTL-SDR devices to use automatic gain control via new `agc` option
- initialize tuner and digital AGC when enabled; manual gain handling unchanged otherwise

## Testing
- `pre-commit run --files src/input-rtlsdr.h src/input-rtlsdr.cpp` *(fails: command not found)*
- `pip install pre-commit` *(fails: could not find a version that satisfies pre-commit)*
- `cmake -S . -B build` *(fails: required packages were not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ebff45eb4833391e69c23c3b661ef