### PR TITLE
fix: ensure file_upload ends with newline

### DIFF
--- a/src/file_upload.cpp
+++ b/src/file_upload.cpp
@@ -186,4 +186,3 @@ void scan_pending_uploads() {
         }
     }
 }
-


### PR DESCRIPTION
## Summary
- drop stray blank line at the end of `file_upload.cpp` so formatting passes

## Testing
- `./scripts/reformat_code`

------
https://chatgpt.com/codex/tasks/task_e_689ecddde7148333a57efa48a992fc90